### PR TITLE
Allow passing data to interpret() that is part of the context() function

### DIFF
--- a/docs/api/createMachine.md
+++ b/docs/api/createMachine.md
@@ -35,4 +35,26 @@ An object of states, where each key is a state name, and the values are one of [
 
 ## context
 
+<code class="api-signature">context(event)</code>
+
 A second argument to `createMachine` is the `context` for the machine; a function that returns an object of [extended state values](https://patterns.eecs.berkeley.edu/?page_id=470#Context). This is useful for storing values coming from places like forms.
+
+The `context` function receives an `event` argument. This is anything passed as the third argument to [interpret](./interpret.html) like so:
+
+```js
+const context = event => ({
+  foo: event.foo
+});
+
+const machine = createMachine({
+  idle: state()
+}, context);
+
+const event = {
+  foo: 'bar'
+};
+
+interpret(machine, service => {
+  // Do stuff when the service changes.
+}, event);
+```

--- a/docs/api/interpret.md
+++ b/docs/api/interpret.md
@@ -34,11 +34,9 @@ service.send('wake'); // Wake up!
 
 ## Arguments
 
-__signature__: `interpret(machine, onChange)`
+__signature__: `interpret(machine, onChange, event)`
 
 These are the arguments to `interpret`:
-
-
 
 ### machine
 
@@ -49,6 +47,28 @@ The state machine, created with [createMachine](./machine.html) to create a new 
 A [callback](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) that is called when the machine completes a transition. Even if the transition results in returning to the same state, the `onChange` callback is still called.
 
 The `onChange` function is called back with the `service`.
+
+### event
+
+The third argument `event`, can be any object. It is passed to the [context function](./createMachine#context) like so:
+
+```js
+const context = event => ({
+  foo: event.foo
+});
+
+const machine = createMachine({
+  idle: state()
+}, context);
+
+const event = {
+  foo: 'bar'
+};
+
+interpret(machine, service => {
+  // Do stuff when the service changes.
+}, event);
+```
 
 ## Service
 

--- a/machine.js
+++ b/machine.js
@@ -174,10 +174,10 @@ let service = {
   }
 };
 
-export function interpret(machine, onChange) {
+export function interpret(machine, onChange, event) {
   let s = Object.create(service, {
     machine: valueEnumerableWritable(machine),
-    context: valueEnumerableWritable(machine.context()),
+    context: valueEnumerableWritable(machine.context(event)),
     onChange: valueEnumerable(onChange)
   });
   s.send = s.send.bind(s);

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -1,7 +1,6 @@
 import { createMachine, interpret, state, transition } from '../machine.js';
 
 QUnit.module('States', hooks => {
-
   QUnit.test('Basic state change', assert => {
     assert.expect(5);
     let machine = createMachine({
@@ -20,5 +19,17 @@ QUnit.module('States', hooks => {
     assert.equal(service.machine.current, 'two');
     service.send('pong');
     assert.equal(service.machine.current, 'one');
+  });
+
+  QUnit.test('Data can be passed into the initial context', assert => {
+    let machine = createMachine({
+      one: state()
+    }, ev => ({ foo: ev.foo }));
+
+    let service = interpret(machine, () => {}, {
+      foo: 'bar'
+    });
+
+    assert.equal(service.context.foo, 'bar', 'works!');
   });
 });


### PR DESCRIPTION
This allows passing data to the context() function through a third argument in interpret.

```js
const context = event => ({
  foo: event.foo
});

const machine = createMachine({
  idle: state()
}, context);

const event = {
  foo: 'bar'
};

interpret(machine, service => {
  // Do stuff when the service changes.
}, event);
```