### PR TITLE
Allow an initial state

### DIFF
--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.30 kB"
+      "maxSize": "1.333 kB"
     }
   ]
 }

--- a/debug.js
+++ b/debug.js
@@ -4,7 +4,10 @@ function unknownState(state) {
   throw new Error(`Cannot transition to unknown state: ${state}`);
 }
 
-d._create = function(states) {
+d._create = function(current, states) {
+  if(!(current in states)) {
+    throw new Error(`Initial state [${current}] is not a known state.`);
+  }
   for(let p in states) {
     let state = states[p];
     for(let [, candidates] of state.transitions) {

--- a/docs/api/createMachine.md
+++ b/docs/api/createMachine.md
@@ -29,6 +29,26 @@ const machine = createMachine({
 }, context);
 ```
 
+## [initial]
+
+Optionally can provide the initial state as the first argument. If no initial state is provided then the first state listed will be the initial state.
+
+```js
+const toggleMachine = initial => createMachine(initial, {
+  active: state(
+    transition('toggle', 'inactive')
+  ),
+  inactive: state(
+    transition('toggle', 'active')
+  )
+});
+
+const myMachine = toggleMachine('inactive');
+const service = interpret(myMachine, () => {});
+
+console.log(service.machine.current, 'inactive');
+```
+
 ## states
 
 An object of states, where each key is a state name, and the values are one of [state](./state.html) or [invoke](./invoke.html).

--- a/machine.js
+++ b/machine.js
@@ -128,9 +128,14 @@ let machine = {
     };
   }
 };
-export function createMachine(states, contextFn = empty) {
-  if(d._create) d._create(states);
-  let current = Object.keys(states)[0];
+
+export function createMachine(current, states, contextFn = empty) {
+  if(typeof current !== 'string') {
+    contextFn = states || empty;
+    states = current;
+    current = Object.keys(states)[0];
+  }
+  if(d._create) d._create(current, states);
   return create(machine, {
     context: valueEnumerable(contextFn),
     current: valueEnumerable(current),

--- a/test/test-debug.js
+++ b/test/test-debug.js
@@ -27,3 +27,14 @@ QUnit.test('Does not error for transitions to states when state does exist', ass
     assert.ok(false, 'Should not have errored');
   }
 });
+
+QUnit.test('Errors if an invalid initial state is provided', assert => {
+  try {
+    createMachine('oops', {
+      one: state()
+    });
+    assert.ok(false, 'should have failed');
+  } catch(e) {
+    assert.ok(true, 'it errored');
+  }
+});

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -32,4 +32,23 @@ QUnit.module('States', hooks => {
 
     assert.equal(service.context.foo, 'bar', 'works!');
   });
+
+  QUnit.test('First argument sets the initial state', assert => {
+    let machine = createMachine('two', {
+      one: state(transition('next', 'two')),
+      two: state(transition('next', 'three')),
+      three: state()
+    });
+
+    let service = interpret(machine, () => {});
+    assert.equal(service.machine.current, 'two', 'in the initial state');
+
+    machine = createMachine('two', {
+      one: state(transition('next', 'two')),
+      two: state(),
+    });
+    service = interpret(machine, () => {});
+    assert.equal(service.machine.current, 'two', 'in the initial state');
+    assert.equal(service.machine.state.value.final, true, 'in the final state');
+  });
 });


### PR DESCRIPTION
This makes it possible to provide an initial state as the first argument
to `createMachine()`. Closes #50