### PR TITLE
Add support for `action`, as a way to perform side-effects

### DIFF
--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.333 kB"
+      "maxSize": "1.335 kB"
     }
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@ __Table of Contents__
     * [transition](./api/transition.html)
       * [guard](./api/guard.html)
       * [reduce](./api/reduce.html)
+      * [action](./api/action.html)
     * [immediate](./api/immediate.html)
   * [invoke](./api/invoke.html)
 * [interpret](./api/interpret.html)

--- a/docs/api/action.md
+++ b/docs/api/action.md
@@ -1,0 +1,34 @@
+---
+layout: api.njk
+title: action
+tags: api
+permalink: api/action.html
+---
+
+# action
+
+__action__ takes a function that will be run during a [transition](./transition.html). The primary purpose of using action is to perform *side-effects*.
+
+This example triggers an event on an element when transitioning to the next state.
+
+```js
+import { createMachine, action, state, transition } from 'robot3';
+
+function dispatchOn(ctx) {
+  const { element } = ctx;
+  element.dispatchEvent(new CustomEvent('toggled'));
+}
+
+const machine = createMachine({
+  on: state(
+    transition('toggle', 'off')
+  ),
+  off: state(
+    transition('toggle', 'on',
+      action(dispatchOn)
+    )
+  )
+}, () => ({
+  element: document.querySelector('#toggler')
+}));
+```

--- a/test/test-action.js
+++ b/test/test-action.js
@@ -1,0 +1,21 @@
+import { createMachine, action, interpret, state, transition } from '../machine.js';
+
+QUnit.module('Action', () => {
+  QUnit.test('Can be used to do side-effects', assert => {
+    let count = 0;
+    let orig = {};
+    let machine = createMachine({
+      one: state(
+        transition('ping', 'two',
+          action(() => count++)
+        )
+      ),
+      two: state()
+    }, () => orig);
+    let service = interpret(machine, () => {});
+    service.send('ping');
+
+    assert.equal(service.context, orig, 'context stays the same');
+    assert.equal(count, 1, 'side-effect performed');
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,4 +3,5 @@ import './test-invoke.js';
 import './test-guard.js';
 import './test-immediate.js';
 import './test-reduce.js';
+import './test-action.js';
 import './test-debug.js';


### PR DESCRIPTION
This adds a new export, `action`, which can be used to perform
side-effects.

This is used during transitions and takes the `context` and the `event`,
just like reducers.

I also refactored transitions/immediates since that code was mostly the
same. The result of the refactor means this new feature only adds 2
bytes.