### PR TITLE
Thread through events for context creators and guards

### DIFF
--- a/docs/integrations/lit-robot.md
+++ b/docs/integrations/lit-robot.md
@@ -128,10 +128,12 @@ render() {
 
 ## Setting the element on context
 
-Some times you might want to perform side-effects on the element instance within a state machine. The best way to do that is to have the element on the context object. The context function receives an event that contains an `element` property. Use that to establish your initial context:
+Some times you might want to perform side-effects on the element instance within a state machine. The best way to do that is to have the element on the context object. The context function receives an event that contains an `element` property. Use that to establish your initial context.
+
+Once the element is on your context you can use [actions](../api/action.html) to perform side-effects.
 
 ```js
-import { createMachine, state } from 'robot3';
+import { createMachine, action, state, transition } from 'robot3';
 import { Robot } from 'lit-robot';
 import { LitElement } from 'lit-element';
 
@@ -140,7 +142,13 @@ const context = ev => ({
 });
 
 const machine = createMachine({
-  idle: state()
+  idle: state(
+    transition('next-page',
+      action((ctx, ev) => {
+        ctx.element.setAttribute('page', ev.page);
+      })
+    )
+  )
 }, context);
 
 class MyApp extends Robot(LitElement) {

--- a/docs/integrations/robot-hooks.md
+++ b/docs/integrations/robot-hooks.md
@@ -15,10 +15,10 @@ __Example__
 
 ```js
 import { createMachine, state, transition } from 'robot3';
-import { component, useMemo, useState, html } from 'haunted';
+import { component, useEffect, useState, html } from 'haunted';
 import { createUseMachine } from 'robot-hooks';
 
-const useMachine = createUseMachine(useMemo, useState);
+const useMachine = createUseMachine(useEffect, useState);
 
 const machine = createMachine({
   idle: state(
@@ -62,9 +62,9 @@ At present the __robot-hooks__ library has one export, `createUseMachine`.
 
 ## createUseMachine
 
-__signature__: `createUseMachine(useMemo, useState)`.
+__signature__: `createUseMachine(useEffect, useState)`.
 
-The `createUseMachine` function creates a `useMachine` hook. It expects 2 hooks from the parent hooks implementation; [useMemo](https://reactjs.org/docs/hooks-reference.html#usememo) and [useState](https://reactjs.org/docs/hooks-reference.html#usestate). This will work with any hooks library that supports these functions.
+The `createUseMachine` function creates a `useMachine` hook. It expects 2 hooks from the parent hooks implementation; [useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect) and [useState](https://reactjs.org/docs/hooks-reference.html#usestate). This will work with any hooks library that supports these functions.
 
 ### useMachine
 

--- a/machine.js
+++ b/machine.js
@@ -136,7 +136,7 @@ export function createMachine(current, states, contextFn = empty) {
 function transitionTo(service, fromEvent, candidates) {
   let { machine, context } = service;
   for(let { to, guards, reducers } of candidates) {  
-    if(guards(context)) {
+    if(guards(context, fromEvent)) {
       service.context = reducers.call(service, context, fromEvent);
 
       let original = machine.original || machine;
@@ -174,7 +174,7 @@ let service = {
 export function interpret(machine, onChange, initialContext, event) {
   let s = Object.create(service, {
     machine: valueEnumerableWritable(machine),
-    context: valueEnumerableWritable(machine.context(initialContext)),
+    context: valueEnumerableWritable(machine.context(initialContext, event)),
     onChange: valueEnumerable(onChange)
   });
   s.send = s.send.bind(s);

--- a/test/test-guard.js
+++ b/test/test-guard.js
@@ -31,4 +31,20 @@ QUnit.module('Guards', hooks => {
     service.send('ping');
     assert.equal(service.machine.current, 'one');
   });
+
+  QUnit.test('Guards are passed the event', assert => {
+    let machine = createMachine({
+      one: state(
+        transition('ping', 'two',
+          guard((ctx, ev) => ev.canProceed)
+        )
+      ),
+      two: state()
+    });
+    let service = interpret(machine, () => {});
+    service.send({ type: 'ping' });
+    assert.equal(service.machine.current, 'one', 'still in the initial state');
+    service.send({ type: 'ping', canProceed: true });
+    assert.equal(service.machine.current, 'two', 'now moved');
+  });
 });

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -1,4 +1,4 @@
-import { createMachine, interpret, state, transition } from '../machine.js';
+import { createMachine, interpret, invoke, state, transition } from '../machine.js';
 
 QUnit.module('States', hooks => {
   QUnit.test('Basic state change', assert => {
@@ -50,5 +50,20 @@ QUnit.module('States', hooks => {
     service = interpret(machine, () => {});
     assert.equal(service.machine.current, 'two', 'in the initial state');
     assert.equal(service.machine.state.value.final, true, 'in the final state');
+  });
+
+  QUnit.test('Child machines receive the event used to invoke them', assert => {
+    let child = createMachine({
+      final: state()
+    }, (ctx, ev) => ({ count: ev.count }));
+    let parent = createMachine({
+      start: state(
+        transition('next', 'next')
+      ),
+      next: invoke(child)
+    });
+    let service = interpret(parent, () => {});
+    service.send({ type: 'next', count: 14 });
+    assert.equal(service.child.context.count, 14, 'event sent through');
   });
 });


### PR DESCRIPTION
This fills out the API so that the `(ctx, ev)` signature is used on all
fo the methods. So this adds the event to:

* The context function for when services are created.
* The `guard` functions.

Closes #61