### PR TITLE
[Docs] Fix broken links

### DIFF
--- a/docs/api/interpret.md
+++ b/docs/api/interpret.md
@@ -40,7 +40,7 @@ These are the arguments to `interpret`:
 
 ### machine
 
-The state machine, created with [createMachine](./machine.html) to create a new service for.
+The state machine, created with [createMachine](./createMachine.html) to create a new service for.
 
 ### onChange
 
@@ -50,7 +50,7 @@ The `onChange` function is called back with the `service`.
 
 ### event
 
-The third argument `event`, can be any object. It is passed to the [context function](./createMachine#context) like so:
+The third argument `event`, can be any object. It is passed to the [context function](./createMachine.html#context) like so:
 
 ```js
 const context = event => ({
@@ -90,4 +90,4 @@ service.send('wake');
 
 #### context
 
-The `context` for the service is an object that results from the [context function](./createMachine.html) when creating the machine, as well as any [reducers](./reduce.html) that have run as a result of state changes.
+The `context` for the service is an object that results from the [context function](./createMachine.html#context) when creating the machine, as well as any [reducers](./reduce.html) that have run as a result of state changes.

--- a/docs/api/invoke.md
+++ b/docs/api/invoke.md
@@ -12,9 +12,6 @@ __Table of Contents__
 
 A special type of [state](./state.html) that immediately invokes a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)-returning function or another [machine](./createMachine.html).
 
-__Table of Contents__
-@[toc]
-
 When the invoker resolves the [service](./interpret.html) will send the `done` event. The arguments to `invoke` can be any of the same things as [state](./state.html), but will mostly be [transitions](./transition.html).
 
 ```js
@@ -118,7 +115,7 @@ The event includes a `data` property that contains the data from the resolved Pr
 }
 ```
 
-Use a [reducer](./reduce.html) to capture the `data` and store the result on the [machine context](./createMachine#context).
+Use a [reducer](./reduce.html) to capture the `data` and store the result on the [machine context](./createMachine.html#context).
 
 ```js
 import { createMachine, invoke, reduce, state, transition } from 'robot3';

--- a/docs/api/reduce.md
+++ b/docs/api/reduce.md
@@ -7,7 +7,7 @@ permalink: api/reduce.html
 
 # reduce
 
-__reduce__ takes a reducer function for changing the [context](#createMachine) of the machine. A common use case is to set values coming from form fields.
+__reduce__ takes a reducer function for changing the [context](./createMachine.html#context) of the machine. A common use case is to set values coming from form fields.
 
 In this example are implementing a login form that sets the `login` and `password` properties on the context.
 

--- a/docs/api/transition.md
+++ b/docs/api/transition.md
@@ -9,9 +9,9 @@ permalink: api/transition.html
 
 A __transition__ is used to move from one state to another. Transitions are triggered by *events*, the first argument to the `transition` function. The second argument is the *destination state*.
 
-Optionally you can add [guards](#guard) and [reducers](#reduce) to transitions. Guards will be applied first; if a guard returns `false` the reducers will not run.
+Optionally you can add [guards](./guard.html) and [reducers](./reduce.html) to transitions. Guards will be applied first; if a guard returns `false` the reducers will not run.
 
-Transitions are *always* a child of either [state](#state) or [invoke](#invoke) types. Here's a typical transition from one state to another:
+Transitions are *always* a child of either [state](./state.html) or [invoke](./invoke.html) types. Here's a typical transition from one state to another:
 
 ```js
 import { createMachine, state, transition } from 'robot3';
@@ -26,7 +26,7 @@ const machine = createMachine({
 });
 ```
 
-And similarly when used with an [invoke](#invoke) state:
+And similarly when used with an [invoke](./invoke.html) state:
 
 ```js
 import { createMachine, invoke, state, transition } from 'robot3';
@@ -43,7 +43,7 @@ const machine = createMachine({
 }, () => ({ users: [] }));
 ```
 
-There can be __multiple transitions__ for the same event, in which case the first will be chosen if its [guards](#guard) pass:
+There can be __multiple transitions__ for the same event, in which case the first will be chosen if its [guards](./guard.html) pass:
 
 ```js
 import { createMachine, guard, state, transition } from 'robot3';


### PR DESCRIPTION
Fixes a handful of broken links (I think I got all of them), as well as removes a duplicate table of contents from the invoke doc.