### PR TITLE
Use same type for ActionFunciton as for reduce

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module 'robot3' {
 
   export type GuardFunction<T> = (context: T) => boolean
 
-  export type ActionFunction<T> = (context: T) => boolean
+  export type ActionFunction<T> = (context: T, event: unknown) => boolean
 
   export type ReduceFunction<T> = (context: T, event: unknown) => T
 


### PR DESCRIPTION
As per description in https://github.com/matthewp/robot/pull/59 ActionFunction should have same type signature as ReduceFunction