### PR TITLE
Updates types to match implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,10 @@ declare module 'robot3' {
     context: C
     current: K
     states: S
+    state: {
+      name: K
+      value: MachineState
+    }
   }
 
   export type Action<C> = {
@@ -130,8 +134,8 @@ declare module 'robot3' {
 
   export interface MachineState {
     final: boolean
-    transitions: Map<string, Transition>
-    immediates?: Map<string, Immediate>
+    transitions: Map<string, Transition[]>
+    immediates?: Map<string, Immediate[]>
     enter?: any
   }
 
@@ -143,7 +147,7 @@ declare module 'robot3' {
   }
 
   export interface Service<M extends Machine> {
-    machine: Pick<M, 'current'>
+    machine: M
     context: M['context']
     onChange: InterpretOnChangeFunction<M>
     send: SendFunction


### PR DESCRIPTION
When trying to access `service.machine.state.value.transitions`, as referenced in this issues https://github.com/matthewp/robot/issues/80#issuecomment-555996991, I got TypeScript compiler errors. This patch should appears to fix it. 

Thanks for an awesome library! I'm really enjoying it. 💯 