### PR TITLE
Allow for event object in SendFunction type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,8 @@ declare module 'robot3' {
     service: Service<T>
   ) => void
 
-  export type SendFunction<T = string> = (event: T) => void
+  export type SendEvent = string | { type: string; [key: string]: any }
+  export type SendFunction<T = SendEvent> = (event: T) => void
 
   export type Machine<S = {}, C = {}, K = string> = {
     context: C


### PR DESCRIPTION
Another quick update to the type definitions. The `send` method on the created service appears to allow both a string or an object with a type property plus any other fields to include in the event used by `reduce` and `action`. 