### PR TITLE
Update GuardFunction type to include event param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ declare module 'robot3' {
 
   export type ContextFunction<T> = (event: unknown) => T
 
-  export type GuardFunction<T> = (context: T) => boolean
+  export type GuardFunction<T> = (context: T, event: unknown) => boolean
 
   export type ActionFunction<T> = (context: T, event: unknown) => boolean
 


### PR DESCRIPTION
After working with the `guard` helper, I found a mismatch between the GuardFunction type and the implementation, which includes the `event` data along with `context`. 
