### PR TITLE
update types to allow for initialContext in interpret function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,7 @@ declare module 'robot3' {
   export function interpret<M extends Machine, E>(
     machine: M,
     onChange?: InterpretOnChangeFunction<typeof machine>,
+    initialContext?: M['context'],
     event?: { [K in keyof E]: any }
   ): Service<typeof machine>
 
@@ -96,7 +97,7 @@ declare module 'robot3' {
 
   /* General Types */
 
-  export type ContextFunction<T> = (event: unknown) => T
+  export type ContextFunction<T> = (context: T, event: unknown) => T
 
   export type GuardFunction<T> = (context: T, event: unknown) => boolean
 


### PR DESCRIPTION
Just another round of type updates after digging into using the `initialContext` argument in the `interpret` function and allowing the `ContextFunction<C>` type to receive that `initialContext` value. 