### PR TITLE
Fix: nested machines call 'done' on direct parent service only

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -95,7 +95,7 @@ const machineToThen = machine => function(ctx, ev) {
       this.child = interpret(machine, s => {
         this.onChange(s);
         if(s.machine.state.value.final) {
-          if (s.parent && Object.is(s.parent.machine, this.child.machine)) return;
+          if (s.parent && this.child && Object.is(s.parent.machine, this.child.machine)) return;
           delete this.child;
           resolve(s.context);
         }


### PR DESCRIPTION
Fixes #100 

My approach to fixing the attached issue is based on providing a `parent` context to the nested child machines because the `onChange` handler for a service is called whenever any service, be it parent or child, is changed. So if a “grandChild” machine is invoked and completes, that “done” event is called for the root service’s onChange handler before the “child” service’s onChange. 

I’m not sure if there is another way to ensure only the direct parent service receives the “done” transition event when a child service is completed. 