### PR TITLE
Fix: check nested machines to be in final state

### DIFF
--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.36 kB"
+      "maxSize": "1.351 kB"
     }
   ]
 }

--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.351 kB"
+      "maxSize": "1.347 kB"
     }
   ]
 }

--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.342 kB"
+      "maxSize": "1.36 kB"
     }
   ]
 }

--- a/machine.js
+++ b/machine.js
@@ -93,7 +93,8 @@ const machineToThen = machine => function(ctx, ev) {
   return {
     then: resolve => {
       this.child = interpret(machine, s => {
-        this.onChange(s);
+        if(this.child !== s) this.onChange(s);
+        else this.onChange(this);
         if(s.machine.state.value.final) {
           delete this.child;
           resolve(s.context);

--- a/machine.js
+++ b/machine.js
@@ -94,7 +94,7 @@ const machineToThen = machine => function(ctx, ev) {
     then: resolve => {
       this.child = interpret(machine, s => {
         this.onChange(s);
-        if(Object.is(this.child, s) && s.machine.state.value.final) {
+        if(this.child == s && s.machine.state.value.final) {
           delete this.child;
           resolve(s.context);
         }

--- a/machine.js
+++ b/machine.js
@@ -94,7 +94,7 @@ const machineToThen = machine => function(ctx, ev) {
     then: resolve => {
       this.child = interpret(machine, s => {
         this.onChange(s);
-        if(this.child && this.child.machine.state.value.final && s.machine.state.value.final) {
+        if(Object.is(this.child, s) && s.machine.state.value.final) {
           delete this.child;
           resolve(s.context);
         }

--- a/machine.js
+++ b/machine.js
@@ -93,9 +93,8 @@ const machineToThen = machine => function(ctx, ev) {
   return {
     then: resolve => {
       this.child = interpret(machine, s => {
-        if(this.child !== s) this.onChange(s);
-        else this.onChange(this);
-        if(s.machine.state.value.final) {
+        this.onChange(s);
+        if (this.child && this.child.machine.state.value.final && s.machine.state.value.final) {
           delete this.child;
           resolve(s.context);
         }

--- a/machine.js
+++ b/machine.js
@@ -94,7 +94,7 @@ const machineToThen = machine => function(ctx, ev) {
     then: resolve => {
       this.child = interpret(machine, s => {
         this.onChange(s);
-        if (this.child && this.child.machine.state.value.final && s.machine.state.value.final) {
+        if(this.child && this.child.machine.state.value.final && s.machine.state.value.final) {
           delete this.child;
           resolve(s.context);
         }


### PR DESCRIPTION
fixes #100 #101 in elegant way
with `Object.is(this.child, s)` we make sure there is no more nested not resolved machines left and machines gonna resolve starting from the deepest level up to top