### PR TITLE
feat: robot browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bundlesize": "npm run minify && bundlesize --config bundlesize.json",
     "server": "http-server -p 1965",
     "test": "node-qunit-puppeteer http://localhost:1965/test/test.html 10000",
-    "build": "rollup -d dist -f cjs machine.js debug.js",
+    "build": "rollup -d dist -f cjs machine.js debug.js && rollup -d dist -f umd -n Robot machine.js",
     "preversion": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
When not using bundler like webpack, adding library to page throws an error, as by default it is aimed to be used in node.js