### PR TITLE
Break out invoke types

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
       uses: ianwalter/puppeteer@v2.0.0
     - name: npm install, build, and test
       run: |
-        yarn
+        npm ci
         npm run server &
         npm run bundlesize
         npm test

--- a/bundlesize.json
+++ b/bundlesize.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./machine.min.js",
-      "maxSize": "1.347 kB"
+      "maxSize": "1.39 kB"
     }
   ]
 }

--- a/machine.js
+++ b/machine.js
@@ -81,17 +81,16 @@ export function state(...args) {
   return create(stateType, desc);
 }
 
-let invokeType = {};
-let invokePromiseType = create(invokeType, {
-  enter: valueEnumerable(function(machine, service, event) {
+let invokePromiseType = {
+  enter(machine, service, event) {
     this.fn.call(service, service.context, event)
       .then(data => service.send({ type: 'done', data }))
       .catch(error => service.send({ type: 'error', error }));
     return machine;
-  })
-});
-let invokeMachineType = create(invokeType, {
-  enter: valueEnumerable(function(machine, service, event) {
+  }
+};
+let invokeMachineType = {
+  enter(machine, service, event) {
     service.child = interpret(this.machine, s => {
       service.onChange(s);
       if(service.child == s && s.machine.state.value.final) {
@@ -105,9 +104,8 @@ let invokeMachineType = create(invokeType, {
       return transitionTo(service, machine, { type: 'done', data }, this.transitions.get('done'));
     }
     return machine;
-  })
-})
-
+  }
+};
 export function invoke(fn, ...transitions) {
   let t = valueEnumerable(transitionsToMap(transitions));
   return machine.isPrototypeOf(fn) ?

--- a/machine.js
+++ b/machine.js
@@ -99,6 +99,14 @@ const machineToThen = machine => function(ctx, ev) {
           resolve(s.context);
         }
       }, ctx, ev);
+
+      if(this.child.machine.state.value.final) {
+        let s = this.child;
+        delete this.child;
+
+        resolve(s.context);
+      }
+      
       return { catch: identity };
     }
   };

--- a/test/test-immediate.js
+++ b/test/test-immediate.js
@@ -33,4 +33,20 @@ QUnit.module('Immediate', hooks => {
     service.send('next');
     assert.equal(service.machine.current, 'three');
   });
+
+  QUnit.test('Can immediately transitions past 2 states', assert => {
+    let machine = createMachine({
+      one: state(
+        immediate('two')
+      ),
+      two: state(
+        immediate('three')
+      ),
+      three: state()
+    });
+
+    let service = interpret(machine, () => {});
+    assert.equal(service.machine.current, 'three', 'transitioned to 3');
+    assert.ok(service.machine.state.value.final, 'in the final state');
+  });
 });

--- a/test/test-invoke.js
+++ b/test/test-invoke.js
@@ -246,4 +246,33 @@ QUnit.module('Invoke', hooks => {
     service.child.child.child.send('DONE') // machine four
     assert.equal(c, 8, 'there were 6 transitions');
   });
+
+  QUnit.test('Invoking a machine that immediately finishes', async assert => {
+    assert.expect(1);
+
+    const child = createMachine({
+      nestedOne: state(
+        immediate('nestedTwo')
+      ),
+      nestedTwo: final()
+    });
+
+    const parent = createMachine({
+      one: state(
+        transition('next', 'two')
+      ),
+      two: invoke(child,
+        transition('done', 'three')
+      ),
+      three: final()
+    });
+
+    let service = interpret(parent, s => {
+      // TODO not totally sure if this is correct, but I think it should
+      // hit this only once and be equal to three
+      assert.equal(s.machine.current, 'three');
+    });
+
+    service.send('next');
+  });
 });

--- a/test/test-invoke.js
+++ b/test/test-invoke.js
@@ -57,10 +57,10 @@ QUnit.module('Invoke', hooks => {
   QUnit.test('Can invoke a child machine', async assert => {
     assert.expect(4);
     let one = createMachine({
-      one: state(
-        transition('go', 'two')
+      nestedOne: state(
+        transition('go', 'nestedTwo')
       ),
-      two: final()
+      nestedTwo: final()
     });
     let two = createMachine({
       one: state(

--- a/test/test-state.js
+++ b/test/test-state.js
@@ -1,4 +1,4 @@
-import { createMachine, interpret, invoke, state, transition } from '../machine.js';
+import { createMachine, interpret, invoke, reduce, state, transition } from '../machine.js';
 
 QUnit.module('States', hooks => {
   QUnit.test('Basic state change', assert => {
@@ -60,10 +60,18 @@ QUnit.module('States', hooks => {
       start: state(
         transition('next', 'next')
       ),
-      next: invoke(child)
+      next: invoke(child,
+        transition('done', 'end',
+          reduce((ctx, ev) => ({
+            ...ctx,
+            ...ev.data
+          }))
+        )
+      ),
+      end: state()
     });
     let service = interpret(parent, () => {});
     service.send({ type: 'next', count: 14 });
-    assert.equal(service.child.context.count, 14, 'event sent through');
+    assert.equal(service.context.count, 14, 'event sent through');
   });
 });


### PR DESCRIPTION
This breaks out the two invoke types, promises and machines, so that machine has more control over how its state is entered. This allows immediate transitions out of the child machine, something that wouldn't be possible with the thenable approach previously taken.

Fixes #102 