### PR TITLE
Remove type: module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A function, immutable Finite State Machine library",
   "main": "dist/machine.js",
   "module": "machine.js",
-  "type": "module",
   "files": [
     "dist/",
     "debug.js",


### PR DESCRIPTION
This breaks usage in Node dist the build version is CommonJS.

Closes #84