### PR TITLE
Customise invoke events (`options`)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,7 @@ __Table of Contents__
       * [action](./api/action.html)
     * [immediate](./api/immediate.html)
   * [invoke](./api/invoke.html)
+    * [options](./api/options.html)
 * [interpret](./api/interpret.html)
 
 # Debugging

--- a/docs/api/invoke.md
+++ b/docs/api/invoke.md
@@ -98,9 +98,9 @@ service.child.send('input');
 
 ## Events
 
-An `invoke` state will trigger one of the following events upon completion:
+An `invoke` state will trigger either a success or a failure event upon completion:
 
-### done
+### Success (`done`)
 
 When the Promise resolves successfully the `done` event is sent through the machine. Use a [transition](./transition.html) to capture this event and proceed as you might with any other event.
 
@@ -130,7 +130,23 @@ const machine = createMachine({
 }, () => ({ todos: [] }))
 ```
 
-### error
+The event name can be configured via the `success` key in [options](./options.html):
+
+```js
+import { createMachine, invoke, state, transition, options } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(startTask,
+    options({ success: 'yay' }),
+    transition('yay', 'loaded',
+      reduce((ctx, ev) => ({ ...ctx, todo: ev.data }))
+    )
+  ),
+  loaded: state()
+}, () => ({ todos: [] }))
+```
+
+### Failure (`error`)
 
 The `error` event is sent through the machine in the case where the Promise rejects. Use this event to capture the error and move to an error state, so you can show your users an error message, retry, or handle errors some other way.
 
@@ -153,6 +169,22 @@ const loadTodos = () => Promise.reject("Sorry but you can't do that");
 const machine = createMachine({
   start: invoke(loadTodos,
     transition('error', 'error',
+      reduce((ctx, ev) => ({ ...ctx, error: ev.error }))
+    )
+  ),
+  error: state()
+})
+```
+
+The event name can be configured via the `failure` key in [options](./options.html):
+
+```js
+import { createMachine, invoke, state, transition, options } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(loadTodos,
+    options({ failure: 'nay' }),
+    transition('nay', 'error',
       reduce((ctx, ev) => ({ ...ctx, error: ev.error }))
     )
   ),

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -1,0 +1,24 @@
+---
+layout: api.njk
+title: options
+tags: api
+permalink: api/options.html
+---
+
+# options
+
+Supply __options__ to configure the behaviour of invoke.  Specify the event names to trigger on `success` or `failure`:
+
+```js
+import { createMachine, state, invoke, options } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(runTask,
+    options({ success: 'yay', failure: 'nay' }),
+    transition('yay', 'complete'),
+    transition('nay', 'error')
+  ),
+  complete: state(),
+  error: state()
+});
+```


### PR DESCRIPTION
(This is a competing design with #121)

## 🐞 Motivation

If we transition out of a promise `invoke` state before the promise settles, the new state will receive the `done` or `error` event.  This will likely cause an issue if the new state is also an `invoke` state since the first promise events will be handled by the second state as if they were from the second promise.

```js
let machine = createMachine({
  one: invoke(getFirstPromise,
    transition('done', 'oneDone'),
    transition('error', 'oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  two: invoke(getSecondPromise
    transition('done', 'twoDone') // <-- will transition on first promise success
    transition('error', 'twoError') // <-- will transition on first promise failure
  ),
  twoDone: final(),
  twoError: final(),
});

let service = interpret(machine, () => {});
service.send('skip');
// 🐞DANGER: When the result of `getFirstPromise` resolves, step `two` will transition
```

## 😌 Solution

Supply `options` inside `invoke` to allow customisation of the success or failure event names:

```js
let machine = createMachine({
  one: invoke(getFirstPromise,
    options({ success: 'done(one)', failure: 'error(one) }),
    transition('done(one)', 'oneDone'),
    transition('error(one)', 'oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  two: invoke(getSecondPromise,
    transition('done', 'twoDone') // <-- will not transition on first promise success
    transition('error', 'twoError') // <-- will not transition on first promise failure
  ),
  twoDone: final(),
  twoError: final(),
});

let service = interpret(machine, () => {});
service.send('skip');
// ✅When the result of `getFirstPromise` resolves, step `two` will not transition
```

**Notes**

- `options` expects a single object argument
- `options` expects `success` or `failure` keys
- If multiple `options` are supplied they will be merged

## 🤷 Alternatives

**Special transition functions: `success` or `failure`**

These transitions would be tied to the current promise and state, so that the promise settlement is ignored if a transition has already occurred.

```js
let machine = createMachine({
  one: invoke(getFirstPromise,
    success('oneDone'),
    failure('oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  // ...
```

**Annotate promise factory with event types: `withEvents`**

```js
let machine = createMachine({
  one: invoke(
    withEvents(getFirstPromise, 'done(one)', 'error(one)'),
    transition('done(one)', 'oneDone'),
    transition('error(one)', 'oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  // ...
```