### PR TITLE
Customise invoke events (`withEvents`)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,7 @@ __Table of Contents__
       * [action](./api/action.html)
     * [immediate](./api/immediate.html)
   * [invoke](./api/invoke.html)
+    * [options](./api/options.html)
 * [interpret](./api/interpret.html)
 
 # Debugging

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,7 @@ __Table of Contents__
       * [action](./api/action.html)
     * [immediate](./api/immediate.html)
   * [invoke](./api/invoke.html)
-    * [options](./api/options.html)
+    * [withEvents](./api/withEvents.html)
 * [interpret](./api/interpret.html)
 
 # Debugging

--- a/docs/api/invoke.md
+++ b/docs/api/invoke.md
@@ -98,9 +98,9 @@ service.child.send('input');
 
 ## Events
 
-An `invoke` state will trigger one of the following events upon completion:
+An `invoke` state will trigger either a success or a failure event upon completion:
 
-### done
+### Success (`done`)
 
 When the Promise resolves successfully the `done` event is sent through the machine. Use a [transition](./transition.html) to capture this event and proceed as you might with any other event.
 
@@ -130,7 +130,22 @@ const machine = createMachine({
 }, () => ({ todos: [] }))
 ```
 
-### error
+The event name can be configured via the `success` argument in [withEvents](./withEvents.html):
+
+```js
+import { createMachine, invoke, state, transition, withEvents } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(withEvents(startTask, 'yay'),
+    transition('yay', 'loaded',
+      reduce((ctx, ev) => ({ ...ctx, todo: ev.data }))
+    )
+  ),
+  loaded: state()
+}, () => ({ todos: [] }))
+```
+
+### Failure (`error`)
 
 The `error` event is sent through the machine in the case where the Promise rejects. Use this event to capture the error and move to an error state, so you can show your users an error message, retry, or handle errors some other way.
 
@@ -153,6 +168,21 @@ const loadTodos = () => Promise.reject("Sorry but you can't do that");
 const machine = createMachine({
   start: invoke(loadTodos,
     transition('error', 'error',
+      reduce((ctx, ev) => ({ ...ctx, error: ev.error }))
+    )
+  ),
+  error: state()
+})
+```
+
+The event name can be configured via the `failure` argument in [withEvents](./withEvents.html):
+
+```js
+import { createMachine, invoke, state, transition, withEvents } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(withEvents(loadTodos, 'yay', 'nay'),
+    transition('nay', 'error',
       reduce((ctx, ev) => ({ ...ctx, error: ev.error }))
     )
   ),

--- a/docs/api/withEvents.md
+++ b/docs/api/withEvents.md
@@ -1,0 +1,41 @@
+---
+layout: api.njk
+title: withEvents
+tags: api
+permalink: api/withEvents.html
+---
+
+# withEvents
+
+Use __withEvents__ to configure the events triggered by a promise invoked.  Specify the event names to trigger on `success` or `failure`:
+
+```js
+import { createMachine, state, invoke, withEvents } from 'robot3';
+
+const machine = createMachine({
+  start: invoke(withEvents(runTask, 'yay', 'nay'),
+    transition('yay', 'complete'),
+    transition('nay', 'error')
+  ),
+  complete: state(),
+  error: state()
+});
+```
+
+## Arguments
+
+__signature__: `withEvents(promiseFn, successEvent, failureEvent)`
+
+These are the arguments to `withEvent`:
+
+### promiseFn
+
+The function that will return a promise, as supplied to [invoke](./invoke.html).
+
+### success
+
+The name of the event triggered when the promise resolves.  Defaults to `done`.
+
+### failure
+
+The name of the event triggered when the promise rejects.  Defaults to `error`.

--- a/machine.js
+++ b/machine.js
@@ -81,11 +81,21 @@ export function state(...args) {
   return create(stateType, desc);
 }
 
+export function withEvents(fn, success, failure) {
+  fn.eventOverrides = { success, failure };
+  return fn;
+}
+function getEvents(fn) {
+  let { success='done', failure='error' } = fn.eventOverrides || {};
+  return { success, failure };
+}
+
 let invokePromiseType = {
   enter(machine, service, event) {
+    let { success, failure } = getEvents(this.fn);
     this.fn.call(service, service.context, event)
-      .then(data => service.send({ type: 'done', data }))
-      .catch(error => service.send({ type: 'error', error }));
+      .then(data => service.send({ type: success, data }))
+      .catch(error => service.send({ type: failure, error }));
     return machine;
   }
 };


### PR DESCRIPTION
(This is a competing design with PR #120)

## 🐞 Motivation

If we transition out of a promise `invoke` state before the promise settles, the new state will receive the `done` or `error` event.  This will likely cause an issue if the new state is also an `invoke` state since the first promise events will be handled by the second state as if they were from the second promise.

```js
let machine = createMachine({
  one: invoke(getFirstPromise,
    transition('done', 'oneDone'),
    transition('error', 'oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  two: invoke(getSecondPromise
    transition('done', 'twoDone') // <-- will transition on first promise success
    transition('error', 'twoError') // <-- will transition on first promise failure
  ),
  twoDone: final(),
  twoError: final(),
});

let service = interpret(machine, () => {});
service.send('skip');
// 🐞DANGER: When the result of `getFirstPromise` resolves, step `two` will transition
```

## 😌 Solution

Annotate factory supplied to `invoke` via a new `withEvents` utility to allow customisation of the success or failure event names:

```js
let machine = createMachine({
  one: invoke(withEvents(getFirstPromise, 'done(one)', 'error(one)'),
    transition('done(one)', 'oneDone'),
    transition('error(one)', 'oneError'),
    transition('skip', 'two') // <-- Allows transition before promise resolves
  ),
  oneDone: final(),
  oneError: final(),
  two: invoke(getSecondPromise,
    transition('done', 'twoDone') // <-- will not transition on first promise success
    transition('error', 'twoError') // <-- will not transition on first promise failure
  ),
  twoDone: final(),
  twoError: final(),
});

let service = interpret(machine, () => {});
service.send('skip');
// ✅When the result of `getFirstPromise` resolves, step `two` will not transition
```

**Notes**

- `withEvents` accepts the success then failure event name, pass `undefined` to use the default success name `withEvents(startTask, undefined, 'onError')`

## 🤷 Alternatives

See #120 