### PR TITLE
fix typos in api and guides docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,7 @@ __Table of Contents__
 
 # Debugging
 
-Robot does not verify the correct of the state machines you create by default. This is for bundle size purposes; in production you wouldn't want your machines to throw, and this code takes up valuable space.
+Robot does not verify the correctness of the state machines you create by default. This is for bundle size purposes; in production you wouldn't want your machines to throw, and this code takes up valuable space.
 
 Instead debugging messages are provided by the __debug module__, `robot3/debug`. Simply import the module anywhere before you call `createMachine`.
 

--- a/docs/api/guard.md
+++ b/docs/api/guard.md
@@ -12,7 +12,7 @@ A __guard__ is a method that determines if a transition can proceed. Returning `
 ```js
 import { createMachine, guard, state, transition } from 'robot3';
 
-// Only allow submission of a login and password is entered.
+// Only allow submission if a login and password is entered.
 function canSubmit(ctx) {
   return ctx.login && ctx.password;
 }

--- a/docs/api/immediate.md
+++ b/docs/api/immediate.md
@@ -7,7 +7,7 @@ permalink: api/immediate.html
 
 # immediate
 
-An __immediate__ is a type of transition that occurs immediate; it doesn't wait for an event to proceed. This is a state that immediate proceeds to the next:
+An __immediate__ is a type of transition that occurs immediately; it doesn't wait for an event to proceed. This is a state that immediately proceeds to the next:
 
 ```js
 import { createMachine, reduce, state, transition } from 'robot3';

--- a/docs/guides/comparison-with-xstate.md
+++ b/docs/guides/comparison-with-xstate.md
@@ -13,7 +13,7 @@ XState and Robot share similarities that make them standout from other, more min
 
 * Extended state (context) makes it possible to keep non-state values within the machine.
 * Both can [invoke](https://www.w3.org/TR/scxml/#invoke) external functions as well as other state machines to perform subtasks.
-* Both support [guards](../api/guard.html) to prevent state transitions from occuring on condition.
+* Both support [guards](../api/guard.html) to prevent state transitions from occurring on condition.
 
 Below goes into more detail of the various tradeoffs each makes.
 

--- a/docs/guides/nested-states.md
+++ b/docs/guides/nested-states.md
@@ -1,11 +1,11 @@
 ---
 layout: page.njk
-title: Nested States (Hierarchial states)
+title: Nested States (Hierarchical states)
 tags: guide
 permalink: guides/nested-states.html
 ---
 
-Statecharts support [hierarchial states](https://statecharts.github.io/what-is-a-statechart.html) (or nested states) as a way to deal with the [state explosion](https://statecharts.github.io/state-machine-state-explosion.html) problem of traditional finite state machines.
+Statecharts support [hierarchical states](https://statecharts.github.io/what-is-a-statechart.html) (or nested states) as a way to deal with the [state explosion](https://statecharts.github.io/state-machine-state-explosion.html) problem of traditional finite state machines.
 
 An example of a nested state machine is a crosswalk light. You give the ✋ when the stoplight is __Yellow__ or __Green__. When the stoplight turns __Red__ the crosswalk toggles to 🚶‍♀️. The crosswalk light is a nested state machine of the parent stoplight.
 


### PR DESCRIPTION
Corrected a few typos I found while reading through the api docs and guides