### PR TITLE
Support for es5 javascript targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,22 +137,10 @@
         "@types/babel-types": "*"
       }
     },
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "12.12.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-      "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==",
       "dev": true
     },
     "JSONStream": {
@@ -4849,25 +4837,6 @@
         "glob": "^7.1.3"
       }
     },
-    "rollup": {
-      "version": "1.21.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.4.tgz",
-      "integrity": "sha512-Pl512XVCmVzgcBz5h/3Li4oTaoDcmpuFZ+kdhS/wLreALz//WuDAMfomD3QEYl84NkDu6Z6wV9twlcREb4qQsw==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "^12.7.5",
-        "acorn": "^7.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-          "dev": true
-        }
-      }
-    },
     "run-parallel": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
@@ -5763,6 +5732,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bundlesize": "npm run minify && bundlesize --config bundlesize.json",
     "server": "ws -p 1965",
     "test": "node-qunit-puppeteer http://localhost:1965/test/test.html 10000",
-    "build": "rollup -d dist -f cjs machine.js debug.js",
+    "build": "tsc --moduleResolution node --module commonjs --target es5 --allowJs --outDir ./dist machine.js debug.js",
     "preversion": "npm run build"
   },
   "repository": {
@@ -39,7 +39,7 @@
     "markdown-it": "^9.1.0",
     "markdown-it-toc-and-anchor": "^4.2.0",
     "node-qunit-puppeteer": "^1.0.13",
-    "rollup": "^1.21.4",
-    "terser": "^4.3.1"
+    "terser": "^4.3.1",
+    "typescript": "^4.1.5"
   }
 }


### PR DESCRIPTION
We are trying to adopt `Robot` but our projects target ES5 because we need to support devices with ancient JavaScript runtimes. Our applications have lots of components split across many teams and projects. So for performance reasons, we've agreed upon a standard set of tooling that everyone uses. Transpilation is performed by the TypeScript compiler instead of Babel, but this leaves an issue for Robot as the sources are only available as ES6+.

It would be great if `Robot` could support ES5, by making the commonjs exports es5 compatible. Providing a potential wider audience for this library.

Two potential paths for this:
1. extend existing `rollup` configuration with a transpiler, e.g. `babel`, that can convert to the exports to es5 format.
2. utilise `typescript` compiler to transpile the sources to commonjs and es5 in one step (this is possible as typescript compiler can also consume Javascript sources)

Because there is no actual _concatenation_ of module files actioned by rollup, the proposal would be to consider adopting typescript compiler to provide a simple _commonjs_ and _es5_ transpile step.

So this PR is the implementation of option 2.

_(Import note is that the responsibility to polyfill any ES6+ features is for the project consuming this library)_