### PR TITLE
Add debug message for forbidden transitions

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -19,3 +19,7 @@ d._create = function(current, states) {
     }
   }
 };
+
+d._send = function(eventName, currentStateName) {
+  throw new Error(`No transitions for event ${eventName} from the current state [${currentStateName}]`);
+};

--- a/machine.js
+++ b/machine.js
@@ -163,10 +163,12 @@ function transitionTo(service, machine, fromEvent, candidates) {
 function send(service, event) {
   let eventName = event.type || event;
   let { machine } = service;
-  let { value: state } = machine.state;
+  let { value: state, name: currentStateName } = machine.state;
   
   if(state.transitions.has(eventName)) {
     return transitionTo(service, machine, event, state.transitions.get(eventName)) || machine;
+  } else {
+    if(d._send) d._send(eventName, currentStateName);
   }
   return machine;
 }


### PR DESCRIPTION
# Motivation

Difficulties arise in finding the reason for the lack of switching to the desired state of the machine when sending a large number of events.

# Solution

This request adds the ability to debug the runtime when sending events by throwing new error