### PR TITLE
Add docs for Debug Module stripping

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,10 @@ Robot does not verify the correctness of the state machines you create by defaul
 
 Instead debugging messages are provided by the __debug module__, `robot3/debug`. Simply import the module anywhere before you call `createMachine`.
 
+## Examples of excluding a debug module from a production build
+
+### 1. dev.js
+
 A common pattern is to have a `dev.js` that imports the debug module and your main. This way the `dev.js` is not included in your production build.
 
 __dev.js__
@@ -36,9 +40,75 @@ import 'robot3/debug';
 import './main.js';
 ```
 
-Or if you're using web modules then include a script tag before your main:
+### 2. Web Modules
+
+If you're using web modules then include a script tag before your main:
 
 ```html
 <script type="module" src="https://unpkg.com/robot3/debug"></script>
 <script type="module" src="./main.js"></script>
 ```
+
+### 3. Stripping with Module Bundler
+
+#### 3.1. Rollup
+
+You can use some Rollup-plugins for excluding __debug module__ from production bundle. The easiest option is to use [rollup-plugin-strip-code](https://www.npmjs.com/package/rollup-plugin-strip-code).
+
+__rollup.config.js__
+
+```js
+import stripCode from 'rollup-plugin-strip-code';
+
+// Assuming you'd run it with something like 'rollup -c --environment BUILD:production'
+const isProduction = process.env.BUILD === 'production';
+
+export default [
+  input: ...,
+  output: ...,
+  plugins: [
+    ...,
+    isProduction && stripCode({
+      start_comment: 'START.DEBUG_ONLY',
+      end_comment: 'END.DEBUG_ONLY',
+    })
+  ]
+];
+```
+
+__stateMachine.js__
+
+```js
+/*START.DEBUG_ONLY*/
+import 'robot3/debug';
+/*END.DEBUG_ONLY*/
+
+import {...} from 'robot3';
+```
+
+Also you can use official [@rollup/plugin-alias](https://www.npmjs.com/package/@rollup/plugin-alias) to mock ```import 'robot3/debug'```, but this approach needs empty mock-file for replacement, what is not so clean.
+
+__rollup.config.js__
+
+```js
+import alias from '@rollup/plugin-alias';
+
+module.exports = {
+  input: ...,
+  output: ...,
+  plugins: [
+    ...,
+    alias({
+      entries: [
+        { find: 'robot3/debug', replacement: resolve(__dirname, './src/mocks/empty.js') },
+      ]
+    })
+  ]
+};
+```
+
+__mocks/empty.js__ is empty file.
+
+#### 3.2. Webpack
+
+Similarly to Rollup you can use [webpack-strip-block](https://www.npmjs.com/package/webpack-strip-block) to strip __debug module__ from production bundle.


### PR DESCRIPTION
Improved documentation on excluding __debug module__ using Module Bundlers