### PR TITLE
Fix logging of previous state.

### DIFF
--- a/logging.js
+++ b/logging.js
@@ -5,7 +5,7 @@ d._onEnter = function(machine, to, state, prevState, event) {
   console.groupCollapsed(`Details:`);
   console.log(`Machine`, machine);
   console.log(`Current state`, state);
-  console.log(`Previous state`, state);
+  console.log(`Previous state`, prevState);
 
   if (typeof event === "string") {
     console.log(`Event ${event}`);


### PR DESCRIPTION
Log message has the label "Previous state" but logs the current state.
Expected the log message to contain previous state.