### PR TITLE
Issue 179: `onChange` not called for `immediate` states

### DIFF
--- a/.changeset/good-foxes-build.md
+++ b/.changeset/good-foxes-build.md
@@ -1,0 +1,5 @@
+---
+"robot3": major
+---
+
+Call onChange callbacks for immediate states too

--- a/packages/core/machine.js
+++ b/packages/core/machine.js
@@ -161,6 +161,8 @@ function transitionTo(service, machine, fromEvent, candidates) {
 
       if (d._onEnter) d._onEnter(machine, to, service.context, context, fromEvent);
       let state = newMachine.state.value;
+      service.machine = newMachine;
+      service.onChange(service);
       return state.enter(newMachine, service, fromEvent);
     }
   }
@@ -181,10 +183,7 @@ function send(service, event) {
 
 let service = {
   send(event) {
-    this.machine = send(this, event);
-    
-    // TODO detect change
-    this.onChange(this);
+    send(this, event);
   }
 };
 

--- a/packages/core/test/test-invoke.js
+++ b/packages/core/test/test-invoke.js
@@ -314,7 +314,8 @@ QUnit.module('Invoke', hooks => {
   });
 
   QUnit.test('Invoking a machine that immediately finishes', async assert => {
-    assert.expect(1);
+    assert.expect(3);
+    const expectations = [ 'two', 'nestedTwo', 'three' ];
 
     const child = createMachine({
       nestedOne: state(
@@ -336,7 +337,7 @@ QUnit.module('Invoke', hooks => {
     let service = interpret(parent, s => {
       // TODO not totally sure if this is correct, but I think it should
       // hit this only once and be equal to three
-      assert.equal(s.machine.current, 'three');
+      assert.equal(s.machine.current, expectations.shift());
     });
 
     service.send('next');


### PR DESCRIPTION
This PR solves issue #179; it makes sure `onChange()` is called for every state the machine transitions to.

There is an additional side effect to this change: it doesn't call `onChange()` when `send()` is called with an unsupported event name. That is, if a state only has a transition triggering on the "done" event, `onChange()` would be called even when executing `send("fail")`. This commit does *not* eliminate the case where the machine transitions from and to one and the same state, although with this change, detecting that situation and eliminating the invocations should be trivial.