### PR TITLE
fix -- issues/198

### DIFF
--- a/.changeset/short-months-sing.md
+++ b/.changeset/short-months-sing.md
@@ -1,0 +1,5 @@
+---
+"robot3": patch
+---
+
+Adding an export property to the core package.json for 'import' so that destructured imports work, in addition to the default imports handled by the 'default' property

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": {
       "require": "./dist/machine.js",
+      "import": "./machine.js",
       "default": "./machine.js"
     }
   },


### PR DESCRIPTION
---
"robot3": patch
---

Adding an export property to the core package.json for 'import' so that destructured imports work, in addition to the default imports handled by the 'default' property