### PR TITLE
add meta tags for page previews

### DIFF
--- a/docs/_includes/page.njk
+++ b/docs/_includes/page.njk
@@ -6,6 +6,18 @@ title: Robot
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{ title }}</title>
+<meta name="title" content="{{ title }}" />
+<meta name="description" content="With Robot you can build finite state machines in a simple and flexible way." />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://thisrobot.life/" />
+<meta property="og:title" content="{{ title }}" />
+<meta property="og:description" content="With Robot you can build finite state machines in a simple and flexible way." />
+<meta property="og:image" content="https://thisrobot.life/images/robot-mono.png" />
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:url" content="https://thisrobot.life/" />
+<meta property="twitter:title" content="{{ title }}" />
+<meta property="twitter:description" content="With Robot you can build finite state machines in a simple and flexible way." />
+<meta property="twitter:image" content="https://thisrobot.life/images/robot-mono.png" />
 <link rel="stylesheet" href="{{ '/styles/main.css' | relUrl(page.url) }}">
 <link rel="stylesheet" href="{{ '/styles/prism-xonokai.css' | relUrl(page.url) }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/images/apple-touch-icon.png' | relUrl(page.url) }}">


### PR DESCRIPTION
This allows for https://thisrobot.life to offer a description and image when previewed in platforms like Discord or the usual social networks. 