### PR TITLE
Update package.json

### DIFF
--- a/.changeset/six-terms-shake.md
+++ b/.changeset/six-terms-shake.md
@@ -1,0 +1,15 @@
+---
+"robot3": patch
+---
+
+### WHAT: 
+
+Explicitly routing the right place for the index.d.ts file 
+
+### WHY: 
+
+Types fail to load in some scenarios. F.i PNPM throws the error: "There are types at '/xxxx/node_modules/robot3/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'robot3' library may need to update its package.json or typings."
+
+### HOW:
+
+Added types path for exports in package.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,9 +3,11 @@
   "version": "0.4.1",
   "description": "A functional, immutable Finite State Machine library",
   "main": "dist/machine.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/machine.js",
+ 			"types": "./dist/index.d.ts",
       "import": "./machine.js",
       "default": "./machine.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,11 +3,10 @@
   "version": "0.4.1",
   "description": "A functional, immutable Finite State Machine library",
   "main": "dist/machine.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/machine.js",
- 			"types": "./dist/index.d.ts",
+ 			"types": "./index.d.ts",
       "import": "./machine.js",
       "default": "./machine.js"
     }


### PR DESCRIPTION
Fixes the issue:
```
There are types at '/home/xxx/node_modules/robot3/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'robot3' library may need to update its package.json or typings.
```