### PR TITLE
Add docs explaining how to 'cancel' invoke()

### DIFF
--- a/.changeset/tender-humans-brush.md
+++ b/.changeset/tender-humans-brush.md
@@ -1,0 +1,5 @@
+---
+"robot3": patch
+---
+
+Documentation for advanced use of 'invoke()'


### PR DESCRIPTION
@matthewp, this PR adds documentation for the "cancellation" pattern I've used and which I refer in my response in #185. If you agree, I'd like to explain this use-case in the documentation. Hopefully, people understand from this that they can add any number of transitions to an `invoke()` state.

Closes #185