### PR TITLE
Set deepest nested service to current

### DIFF
--- a/.changeset/hungry-planes-brush.md
+++ b/.changeset/hungry-planes-brush.md
@@ -1,0 +1,6 @@
+---
+"robot-hooks": patch
+"robot3": patch
+---
+
+Set the most deeply nested current service to current

--- a/packages/core/machine.js
+++ b/packages/core/machine.js
@@ -169,8 +169,9 @@ function transitionTo(service, machine, fromEvent, candidates) {
       if (d._onEnter) d._onEnter(machine, to, service.context, context, fromEvent);
       let state = newMachine.state.value;
       service.machine = newMachine;
+      let ret = state.enter(newMachine, service, fromEvent);
       service.onChange(service);
-      return state.enter(newMachine, service, fromEvent);
+      return ret;
     }
   }
 }

--- a/packages/core/test/test-invoke.js
+++ b/packages/core/test/test-invoke.js
@@ -359,7 +359,7 @@ QUnit.module('Invoke', hooks => {
 
   QUnit.test('Invoking a machine that immediately finishes', async assert => {
     assert.expect(3);
-    const expectations = [ 'two', 'nestedTwo', 'three' ];
+    const expectations = [ 'nestedTwo', 'three', 'three' ];
 
     const child = createMachine({
       nestedOne: state(
@@ -379,8 +379,6 @@ QUnit.module('Invoke', hooks => {
     });
 
     let service = interpret(parent, s => {
-      // TODO not totally sure if this is correct, but I think it should
-      // hit this only once and be equal to three
       assert.equal(s.machine.current, expectations.shift());
     });
 

--- a/packages/robot-hooks/machine.js
+++ b/packages/robot-hooks/machine.js
@@ -24,7 +24,11 @@ export function createUseMachine(useEffect, useState) {
         if (!mounted) {
           return;
         }
-        setCurrent(createCurrent(service.child || service));
+        let currentService = service;
+        while(currentService.child) {
+          currentService = currentService.child;
+        }
+        setCurrent(createCurrent(currentService));
       }, data || initialContext);
     }
 

--- a/packages/robot-hooks/test/test.js
+++ b/packages/robot-hooks/test/test.js
@@ -139,7 +139,7 @@ QUnit.module('useMachine', hooks => {
         transition('next', 'deepTwo')
       ),
       deepTwo: state(),
-    })
+    });
     const nested = createMachine({
       nestedOne: state(
         transition('next', 'nestedTwo')

--- a/packages/robot-hooks/test/test.js
+++ b/packages/robot-hooks/test/test.js
@@ -133,12 +133,19 @@ QUnit.module('useMachine', hooks => {
     el.remove();
   });
 
-  QUnit.skip('Invoking machines the "current" is the child machine', async assert => {
+  QUnit.test('Invoking machines the "current" is the child machine', async assert => {
+    const deep = createMachine({
+      deepOne: state(
+        transition('next', 'deepTwo')
+      ),
+      deepTwo: state(),
+    })
     const nested = createMachine({
       nestedOne: state(
         transition('next', 'nestedTwo')
       ),
-      nestedTwo: state()
+      nestedTwo: invoke(deep, transition('done', 'nestedThree')),
+      nestedThree: state()
     });
     const machine = createMachine({
       one: state(
@@ -150,11 +157,9 @@ QUnit.module('useMachine', hooks => {
       three: state()
     });
 
-    let current, send, service;
+    let service;
     function App() {
-      const [currentState, sendEvent, thisService] = useMachine(machine);
-      current = currentState;
-      send = sendEvent;
+      const [current, _send, thisService] = useMachine(machine);
       service = thisService;
 
       return html`
@@ -167,10 +172,13 @@ QUnit.module('useMachine', hooks => {
       let text = () => el.textContent.trim();
 
       assert.equal(text(), 'State: one');
-      yield send('next');
+      yield service.send('next');
 
       assert.equal(text(), 'State: nestedOne');
       yield service.child.send('next');
+
+      assert.equal(text(), 'State: deepOne');
+      yield service.child.child.send('next');
       
       assert.equal(text(), 'State: three');
     });


### PR DESCRIPTION
This makes it so that we always use the deepest nested service as the `current`.

This is not a breaking change as this is current expected behavior. We were passing `service.child` to be the new current, but not accounting for the possibility of deeply nested machines.

Fixes https://github.com/matthewp/robot/issues/195