### PR TITLE
Support typed events in hook send()

### DIFF
--- a/.changeset/green-pants-search.md
+++ b/.changeset/green-pants-search.md
@@ -1,0 +1,16 @@
+---
+"robot-hooks": minor
+"haunted-robot": minor
+"preact-robot": minor
+"react-robot": minor
+---
+
+Typed event for send() in hooks
+
+This adds the same typed event support for `send()` from hooks, for ex in React:
+
+```ts
+const [state, send] = useMachine(machine);
+
+send('this-is-typed');
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9962,7 +9962,7 @@
     },
     "packages/core": {
       "name": "robot3",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "rollup": "^1.21.4",
@@ -9989,7 +9989,7 @@
       "license": "BSD-2-Clause",
       "devDependencies": {
         "lit": "^3.1.3",
-        "robot3": "1.0.2"
+        "robot3": "1.1.0"
       },
       "peerDependencies": {
         "lit": "^3.1.3",
@@ -10068,17 +10068,17 @@
       }
     },
     "packages/react-robot": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "robot-hooks": "^1.0.0"
       },
       "devDependencies": {
         "react-dom": "^18.2.0",
-        "robot3": "^1.0.0"
+        "robot3": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18.2.0",
+        "react": "^16.9.0 || ^17.0.0 || ^18.2.0 || ^19.0.0",
         "robot3": "^1.0.0"
       }
     },
@@ -14375,7 +14375,7 @@
       "version": "file:packages/lit-robot",
       "requires": {
         "lit": "^3.1.3",
-        "robot3": "1.0.2"
+        "robot3": "1.1.0"
       },
       "dependencies": {
         "@lit/reactive-element": {
@@ -16162,7 +16162,7 @@
       "requires": {
         "react-dom": "^18.2.0",
         "robot-hooks": "^1.0.0",
-        "robot3": "^1.0.0"
+        "robot3": "^1.1.0"
       }
     },
     "read-pkg": {

--- a/packages/robot-hooks/index.d.ts
+++ b/packages/robot-hooks/index.d.ts
@@ -1,11 +1,11 @@
 declare module 'robot-hooks' {
-  import type {Machine, SendFunction, Service} from 'robot3';
+  import type {Machine, SendFunction, Service, GetMachineTransitions} from 'robot3';
   function useMachine<M extends Machine>(
     machine: M,
     initialContext?: M['context']
   ): [
     M['state'] & {context: M['context']},
-    SendFunction,
+    SendFunction<GetMachineTransitions<M>>,
     Service<typeof machine>
   ];
 

--- a/packages/robot-hooks/package.json
+++ b/packages/robot-hooks/package.json
@@ -11,6 +11,8 @@
   ],
   "scripts": {
     "test": "wireit",
+    "test:browser": "wireit",
+    "test:types": "wireit",
     "build": "wireit"
   },
   "repository": {
@@ -33,6 +35,16 @@
   },
   "wireit": {
     "test": {
+      "dependencies": [
+        "test:types",
+        "test:browser"
+      ]
+    },
+    "test:types": {
+      "command": "tsc -p test/types/tsconfig.json",
+      "files": []
+    },
+    "test:browser": {
       "command": "node-qunit-puppeteer http://localhost:1965/packages/robot-hooks/test/test.html 10000",
       "dependencies": [
         "../..:server"

--- a/packages/robot-hooks/test/types/send.ts
+++ b/packages/robot-hooks/test/types/send.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf } from 'expect-type';
+import { test } from 'node:test';
+import {
+  createMachine,
+  transition,
+  state,
+} from 'robot3';
+import {
+  createUseMachine
+} from 'robot-hooks';
+
+test('send(event) is typed', () => {
+  const useMachine = createUseMachine(null, null);
+  const machine = createMachine({
+    one: state(transition('go-two', 'two')),
+    two: state(transition('go-one', 'one')),
+    three: state()
+  });
+
+  const [_state, send] = useMachine(machine);
+
+  type Params = Parameters<typeof send>;
+  type EventParam = Params[0];
+  type StringParams = Extract<EventParam, string>;
+  expectTypeOf<StringParams>().toEqualTypeOf<'go-one' | 'go-two'>();
+
+  type ObjectParams = Extract<EventParam, { type: string; }>;
+  expectTypeOf<ObjectParams['type']>().toEqualTypeOf<'go-one' | 'go-two'>();
+});

--- a/packages/robot-hooks/test/types/tsconfig.json
+++ b/packages/robot-hooks/test/types/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "include": ["../..", "."],
+  "exclude": ["../../node_modules"],
+  "compilerOptions": {
+    /* Base Options: */
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "target": "es2022",
+    "allowJs": false,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "moduleResolution": "nodenext",
+
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    /* AND if you're building for a library: */
+    "declaration": true,
+
+    /* AND if you're building for a library in a monorepo: */
+    "composite": true,
+    "declarationMap": true,
+
+    /* If NOT transpiling with TypeScript: */
+    "module": "nodenext",
+    "noEmit": true,
+
+    /* If your code runs in the DOM: */
+    "lib": ["es2022", "dom", "dom.iterable"]
+  }
+}


### PR DESCRIPTION
This adds the same typed event support for `send()` from hooks, for ex in React:

```ts
const [state, send] = useMachine(machine);

send('this-is-typed');
```