### PR TITLE
docs(createMachine): Add `section`, fix case in `permalink`

### DIFF
--- a/docs/src/content/docs/createMachine.md
+++ b/docs/src/content/docs/createMachine.md
@@ -1,7 +1,8 @@
 ---
 title: createMachine
 tags: api
-permalink: api/createMachine.html
+permalink: api/createmachine.html
+section: api
 ---
 
 The `createMachine` function creates a state machine. It takes an object of *states* with the key being the state name. The value is usually [state](/docs/state/) but might also be [invoke](/docs/invoke/).


### PR DESCRIPTION
Looks like your build _really_ likes lowercase URLs, so that’s why I changed `permalink`.

The other API pages all seem to have the `section` entry in their frontmatter too, so I added it.

**Note:** I looked into this because I noticed that the “breadcrumbs” for the `createMachine` page still shows it as if it it’s part of “Core Concepts”.  I don’t know Astro, so I don’t know if this will fix it. Here’s hopin’!  

(P.S.: Thanks for fixing the deployed site!  Yay! 👍)